### PR TITLE
Fix CI build failure by upgrading Node.js to 18.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -26,4 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
+    - run: npm run build
+      env:
+        NODE_OPTIONS: --openssl-legacy-provider
     - run: npm test


### PR DESCRIPTION
Fixes the failing GitHub Actions CI. The `npm ci` step fails with `Cannot read property '@babel/preset-env' of undefined` because the `package-lock.json` is format version 3, but the CI uses Node.js 14 (which includes the outdated npm v6). Upgrading the Node version to 18 in the workflow solves this issue. It also includes adding `npm run build` and providing the legacy OpenSSL provider option to ensure Webpack compiles successfully with Node 18.

---
*PR created automatically by Jules for task [2880577723990680639](https://jules.google.com/task/2880577723990680639) started by @khmilevoi*